### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: java
+language: shell
 
 os:
-  - linux
   - windows
+  - linux
 
 # This comes from the docs at
 # https://docs.travis-ci.com/user/languages/java/#caching
@@ -13,3 +13,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+script:
+  - ./gradlew assemble
+  - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+os:
+  - linux
+  - windows
+
 # This comes from the docs at
 # https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: shell
-
-os:
-  - windows
-  - linux
+language: java
 
 # This comes from the docs at
 # https://docs.travis-ci.com/user/languages/java/#caching
@@ -13,7 +9,3 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-
-script:
-  - ./gradlew assemble
-  - ./gradlew check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.com/soartech/soar-language-server.svg?branch=master)](https://travis-ci.com/soartech/soar-language-server)
+[![Build status](https://ci.appveyor.com/api/projects/status/odm1cx7f8phh99pw?svg=true)](https://ci.appveyor.com/project/soartech/soar-language-server)
 
 # Soar Language Server
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: "{branch} {build}"
 
+install:
+  - cmd: git submodule -q update --init
+
 build_script:
   - gradlew.bat assemble
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+build_script:
+  - gradlew.bat assemble
+
+test_script:
+  - gradlew.bat check
+
+cache:
+  - C:\Users\appveyor\.gradle
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+version: "{branch} {build}"
+
 build_script:
   - gradlew.bat assemble
 
@@ -6,4 +8,4 @@ test_script:
 
 cache:
   - C:\Users\appveyor\.gradle
-
+  - C:\Users\appveyor\build

--- a/build.gradle
+++ b/build.gradle
@@ -55,23 +55,5 @@ task compileJSoar(type: MavenExec) {
     }
 }
 
-task compileMavenProject(type: Exec) {
-    workingDir "jsoar/"
-    commandLine osAdaptiveCommand("mvn", "--batch-mode", "-Dmaven.test.skip=true", "-Dmaven.javadoc.skip=true", "install")
-}
-
-// Commands on Windows need to be prefixed with `cmd /c`
-// See https://stackoverflow.com/a/54315477
-import org.apache.tools.ant.taskdefs.condition.Os
-private static Iterable<String> osAdaptiveCommand(String... commands) {
-    def newCommands = []
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        newCommands = ['cmd', '/c']
-    }
-
-    newCommands.addAll(commands)
-    return newCommands
-}
-
 // Define the main class for the application
 mainClassName = 'com.soartech.soarls.App'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,20 @@ dependencies {
 
 task compileMavenProject(type: Exec) {
     workingDir "jsoar/"
-    commandLine "mvn", "--batch-mode", "-Dmaven.test.skip=true", "-Dmaven.javadoc.skip=true", "install"
+    commandLine osAdaptiveCommand("mvn", "--batch-mode", "-Dmaven.test.skip=true", "-Dmaven.javadoc.skip=true", "install")
+}
+
+// Commands on Windows need to be prefixed with `cmd /c`
+// See https://stackoverflow.com/a/54315477
+import org.apache.tools.ant.taskdefs.condition.Os
+private static Iterable<String> osAdaptiveCommand(String... commands) {
+    def newCommands = []
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        newCommands = ['cmd', '/c']
+    }
+
+    newCommands.addAll(commands)
+    return newCommands
 }
 
 // Define the main class for the application

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'application'
+    id 'com.github.dkorotych.gradle-maven-exec' version '2.1'
 }
 
 applicationDefaultJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9999']
@@ -36,11 +37,22 @@ dependencies {
     implementation 'com.soartech:jsoar-tcl:4.0-SNAPSHOT'
 
     compile files("jsoar/target/classes") {
-        builtBy "compileMavenProject"
+        builtBy 'compileJSoar'
     }
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
+}
+
+task compileJSoar(type: MavenExec) {
+    workingDir 'jsoar/'
+    goals 'install'
+    options {
+        define = [
+            'maven.test.skip': 'true',
+            'maven.javadoc.skip': 'true'
+        ]
+    }
 }
 
 task compileMavenProject(type: Exec) {


### PR DESCRIPTION
After some floundering around, I was able to replace the direct command line invocation of maven with the `gradle-maven-exec` plugin, and this seems to be working fine on Appveyor.