### PR TITLE
Handle multiple entry points

### DIFF
--- a/src/main/java/com/soartech/soarls/SoarDocumentService.java
+++ b/src/main/java/com/soartech/soarls/SoarDocumentService.java
@@ -779,6 +779,11 @@ public class SoarDocumentService implements TextDocumentService {
 
       PublishDiagnosticsParams diagnostics =
           new PublishDiagnosticsParams(fileAnalysis.uri.toString(), diagnosticList);
+      // NOTE: I believe that publishDiagnostics is NOT thread safe. If multiple analyses complete
+      // at the same time, and they both try to send diagnostics, then the client might get into a
+      // bad state. However, since this method here gets called from the analysis threadpool, which
+      // has been allocated a single thread, it will not be called from mulitple threads at the same
+      // time. If we change the threading model, then we MUST revisit this assumption.
       client.publishDiagnostics(diagnostics);
     }
   }

--- a/src/main/java/com/soartech/soarls/analysis/Analysis.java
+++ b/src/main/java/com/soartech/soarls/analysis/Analysis.java
@@ -9,6 +9,7 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.soartech.soarls.Documents;
 import com.soartech.soarls.EntryPoints;
+import com.soartech.soarls.EntryPoints.EntryPoint;
 import com.soartech.soarls.SoarFile;
 import com.soartech.soarls.tcl.TclAstNode;
 import com.soartech.soarls.tcl.TclParser;
@@ -157,6 +158,7 @@ public class Analysis {
   // counterpart at the end.
 
   private final URI entryPointUri;
+  private final EntryPoint entryPoint;
   private final Map<URI, FileAnalysis> files = new HashMap<>();
   private final Map<String, ProcedureDefinition> procedureDefinitions = new HashMap<>();
   private final Map<ProcedureDefinition, List<ProcedureCall>> procedureCalls = new HashMap<>();
@@ -166,9 +168,11 @@ public class Analysis {
 
   private final Interp tclInterp;
 
-  private Analysis(EntryPoints projectConfig, Documents documents, URI entryPointUri)
+  private Analysis(
+      EntryPoints projectConfig, Documents documents, EntryPoint entryPoint, URI entryPointUri)
       throws SoarException {
     this.projectConfig = projectConfig;
+    this.entryPoint = entryPoint;
     this.documents = documents;
     this.entryPointUri = entryPointUri;
 
@@ -197,10 +201,10 @@ public class Analysis {
 
   /** Perform a full analysis of a project starting from the given entry point. */
   public static ProjectAnalysis analyse(
-      EntryPoints projectConfig, Documents documents, URI entryPointUri) {
+      EntryPoints projectConfig, Documents documents, EntryPoint entryPoint, URI entryPointUri) {
     Analysis analysis = null;
     try {
-      analysis = new Analysis(projectConfig, documents, entryPointUri);
+      analysis = new Analysis(projectConfig, documents, entryPoint, entryPointUri);
       SoarFile file = documents.get(entryPointUri);
       analysis.analyseFile(file);
       LOG.info("Completed analysis {}", analysis);
@@ -217,6 +221,7 @@ public class Analysis {
   private ProjectAnalysis toProjectAnalysis() {
     return new ProjectAnalysis(
         entryPointUri,
+        entryPoint,
         files,
         procedureDefinitions,
         procedureCalls,

--- a/src/main/java/com/soartech/soarls/analysis/ProjectAnalysis.java
+++ b/src/main/java/com/soartech/soarls/analysis/ProjectAnalysis.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.soartech.soarls.EntryPoints.EntryPoint;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,8 @@ import java.util.Optional;
  */
 public class ProjectAnalysis {
   public final URI entryPointUri;
+
+  public final EntryPoint entryPoint;
 
   public final ImmutableMap<URI, FileAnalysis> files;
 
@@ -50,12 +53,14 @@ public class ProjectAnalysis {
    */
   ProjectAnalysis(
       URI entryPointUri,
+      EntryPoint entryPoint,
       Map<URI, FileAnalysis> files,
       Map<String, ProcedureDefinition> procedureDefinitions,
       Map<ProcedureDefinition, List<ProcedureCall>> procedureCalls,
       Map<String, VariableDefinition> variableDefinitions,
       Map<VariableDefinition, List<VariableRetrieval>> variableRetrievals) {
     this.entryPointUri = entryPointUri;
+    this.entryPoint = entryPoint;
     this.files = ImmutableMap.copyOf(files);
     this.procedureDefinitions = ImmutableMap.copyOf(procedureDefinitions);
     this.procedureCalls =

--- a/src/main/java/com/soartech/soarls/util/Debouncer.java
+++ b/src/main/java/com/soartech/soarls/util/Debouncer.java
@@ -18,7 +18,13 @@ import java.util.concurrent.TimeUnit;
 public class Debouncer {
   private Duration delay;
 
-  private final ScheduledExecutorService workerThread = Executors.newScheduledThreadPool(1);
+  /**
+   * We use a single worker thread for all analyses because it is unclear whether or not the JTcl
+   * interpreter is thread safe. Until such time as we determine whether it is (or refactor the
+   * analysis functions if there is only a small critical section to lock in), we should not perform
+   * analyses in parallel.
+   */
+  private static final ScheduledExecutorService workerThread = Executors.newScheduledThreadPool(1);
 
   private Future<?> pendingTask = null;
 

--- a/src/test/java/com/soartech/soarls/BadProjectTest.java
+++ b/src/test/java/com/soartech/soarls/BadProjectTest.java
@@ -9,28 +9,13 @@ import org.junit.jupiter.api.Test;
 public class BadProjectTest extends LanguageServerTestFixture {
   public BadProjectTest() throws Exception {
     super("bad-project");
-    open("test.soar");
-    waitForAnalysis("test.soar");
   }
 
-  /**
-   * Even though the project is missing a manifest, when we open test.soar it should become the
-   * default entry point.
-   */
+  /** When there is a badly formed manifest, we report diagnostics for the soarAgents.json file. */
   @Test
   public void fileWithoutManifest() {
-    List<Diagnostic> diagnostics = diagnosticsForFile("test.soar");
+    List<Diagnostic> diagnostics = diagnosticsForFile("soarAgents.json");
     assertNotNull(diagnostics);
-  }
-
-  /**
-   * We normally report errors about missing files, but in this case the source command is being
-   * wrapped in a Tcl exception handler. It is normal for it to fail, so we shouldn't report an
-   * error.
-   */
-  @Test
-  public void catchSourceException() {
-    List<Diagnostic> diagnostics = diagnosticsForFile("test.soar");
-    assertTrue(diagnostics.isEmpty());
+    assertFalse(diagnostics.isEmpty());
   }
 }

--- a/src/test/java/com/soartech/soarls/HoverTest.java
+++ b/src/test/java/com/soartech/soarls/HoverTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkedString;
-import org.eclipse.lsp4j.MarkupContent;
-import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.junit.jupiter.api.Test;
 
@@ -31,8 +29,8 @@ public class HoverTest extends SingleFileTestFixture {
   public void hoverVariableValue() throws Exception {
     TextDocumentPositionParams params = textDocumentPosition(file, 20, 44);
     Hover hover = languageServer.getTextDocumentService().hover(params).get();
-    MarkupContent contents = hover.getContents().getRight();
-    assertEquals(contents.getKind(), MarkupKind.PLAINTEXT);
+    MarkedString contents = hover.getContents().getLeft().get(0).getRight();
+    assertEquals(contents.getLanguage(), "raw");
     assertEquals(contents.getValue(), "*YES*");
   }
 
@@ -48,7 +46,7 @@ public class HoverTest extends SingleFileTestFixture {
     // The 'L' in '$ALPHA'
     TextDocumentPositionParams params = textDocumentPosition(file, 28, 23);
     Hover hover = languageServer.getTextDocumentService().hover(params).get();
-    MarkupContent contents = hover.getContents().getRight();
+    MarkedString contents = hover.getContents().getLeft().get(0).getRight();
     assertEquals(contents.getValue(), "alpha");
   }
 
@@ -58,7 +56,7 @@ public class HoverTest extends SingleFileTestFixture {
     // The 'E' in 'prefix-$BETA'
     TextDocumentPositionParams params = textDocumentPosition(file, 29, 30);
     Hover hover = languageServer.getTextDocumentService().hover(params).get();
-    MarkupContent contents = hover.getContents().getRight();
+    MarkedString contents = hover.getContents().getLeft().get(0).getRight();
     assertEquals(contents.getValue(), "beta");
   }
 
@@ -170,12 +168,5 @@ public class HoverTest extends SingleFileTestFixture {
     } catch (Exception e) {
       fail("hover threw an exception");
     }
-  }
-
-  @Test
-  public void hoverUnknownFile() throws Exception {
-    TextDocumentPositionParams params = textDocumentPosition("notexistent.soar", 0, 0);
-    Hover hover = languageServer.getTextDocumentService().hover(params).get();
-    assertNull(hover);
   }
 }

--- a/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
+++ b/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
@@ -56,6 +56,23 @@ public class MultipleEntryPointTest extends LanguageServerTestFixture {
     return workspaceRoot.resolve(relativePath).toString();
   }
 
+  @Test
+  void variableDefinitions() throws Exception {
+    // Usage of $agent_name variable
+    TextDocumentPositionParams params = textDocumentPosition("common.soar", 3, 30);
+    List<Location> definitions =
+        languageServer
+            .getTextDocumentService()
+            .definition(params)
+            .get()
+            .getLeft()
+            .stream()
+            .collect(toList());
+    System.out.println(definitions);
+    assertLocation(definitions, "primary.soar", range(0, 0, 0, 22));
+    assertLocation(definitions, "secondary.soar", range(0, 0, 0, 24));
+  }
+
   /** Assert that the list of locations includes the given URI and range. */
   void assertLocation(List<Location> locations, String relativePath, Range range) {
     String uri = resolve(relativePath);

--- a/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
+++ b/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceContext;
@@ -25,8 +25,8 @@ public class MultipleEntryPointTest extends LanguageServerTestFixture {
     TextDocumentPositionParams params = textDocumentPosition("common.soar", 5, 35);
     Hover hover = languageServer.getTextDocumentService().hover(params).get();
 
-    MarkupContent content = hover.getContents().getRight();
-    assertEquals(content.getValue(), "primary");
+    MarkedString content = hover.getContents().getLeft().get(0).getRight();
+    assertEquals(content.getValue(), "primary: primary\nsecondary: secondary");
   }
 
   List<Location> getReferences(String relativePath, int line, int character) throws Exception {

--- a/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
+++ b/src/test/java/com/soartech/soarls/MultipleEntryPointTest.java
@@ -1,0 +1,69 @@
+package com.soartech.soarls;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceContext;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.junit.jupiter.api.Test;
+
+public class MultipleEntryPointTest extends LanguageServerTestFixture {
+  public MultipleEntryPointTest() throws Exception {
+    super("multiple-entry-point");
+  }
+
+  @Test
+  void hoverVariable() throws Exception {
+    // The $agent_name variable
+    TextDocumentPositionParams params = textDocumentPosition("common.soar", 5, 35);
+    Hover hover = languageServer.getTextDocumentService().hover(params).get();
+
+    MarkupContent content = hover.getContents().getRight();
+    assertEquals(content.getValue(), "primary");
+  }
+
+  List<Location> getReferences(String relativePath, int line, int character) throws Exception {
+    ReferenceParams params = new ReferenceParams();
+    params.setTextDocument(fileId(relativePath));
+    params.setPosition(new Position(line, character));
+    params.setContext(new ReferenceContext(false));
+    return languageServer
+        .getTextDocumentService()
+        .references(params)
+        .get()
+        .stream()
+        .collect(toList());
+  }
+
+  @Test
+  void variableReferences() throws Exception {
+    // Definition of agent_name variable
+    List<Location> primaryReferences = getReferences("primary.soar", 0, 10);
+    assertLocation(primaryReferences, "common.soar", range(5, 30, 5, 41));
+
+    List<Location> secondaryReferences = getReferences("secondary.soar", 0, 10);
+    assertLocation(secondaryReferences, "common.soar", range(5, 30, 5, 41));
+  }
+
+  String resolve(String relativePath) {
+    return workspaceRoot.resolve(relativePath).toString();
+  }
+
+  /** Assert that the list of locations includes the given URI and range. */
+  void assertLocation(List<Location> locations, String relativePath, Range range) {
+    String uri = resolve(relativePath);
+    locations
+        .stream()
+        .filter(l -> l.getUri().equals(uri))
+        .filter(l -> l.getRange().equals(range))
+        .findAny()
+        .get();
+  }
+}

--- a/src/test/java/com/soartech/soarls/ProjectTest.java
+++ b/src/test/java/com/soartech/soarls/ProjectTest.java
@@ -28,7 +28,7 @@ public class ProjectTest extends LanguageServerTestFixture {
   @Test
   public void hasErrorsInLoadFile() {
     List<Diagnostic> diagnostics = diagnosticsForFile("load.soar");
-    assert (!diagnostics.isEmpty());
+    assertEquals(diagnostics.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/soartech/soarls/SourceExceptionTest.java
+++ b/src/test/java/com/soartech/soarls/SourceExceptionTest.java
@@ -1,0 +1,25 @@
+package com.soartech.soarls;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+public class SourceExceptionTest extends LanguageServerTestFixture {
+  public SourceExceptionTest() throws Exception {
+    super("source-exception");
+    waitForAnalysis("test.soar");
+  }
+
+  /**
+   * We normally report errors about missing files, but in this case the source command is being
+   * wrapped in a Tcl exception handler. It is normal for it to fail, so we shouldn't report an
+   * error.
+   */
+  @Test
+  public void catchSourceException() {
+    List<Diagnostic> diagnostics = diagnosticsForFile("test.soar");
+    assertTrue(diagnostics.isEmpty());
+  }
+}

--- a/src/test/resources/bad-project/test.soar
+++ b/src/test/resources/bad-project/test.soar
@@ -1,5 +1,4 @@
-# Even though the soarAgents.json file is badly formed, this file
-# should still work.
+# The soarAgents.json file is badly formed, so this file will not be analysed.
 
 set NGS_YES *YES*
 
@@ -8,12 +7,3 @@ sp "elaborate*top-state
 -->
     (<s> ^top-state $NGS_YES)
 "
-
-
-# Using Tcl exceptions is not common in Soar programs, but apparently
-# people do this! The following should not result in an error.
-if { [catch {source "non-existant-file.tcl"}] } {
-    echo ">>>>> no non-existant-file.tcl file"
-} else {
-    echo ">>>>> sourced non-existant-file.tcl"
-}

--- a/src/test/resources/completion/soarAgents.json
+++ b/src/test/resources/completion/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/diagnostics/soarAgents.json
+++ b/src/test/resources/diagnostics/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/hover/soarAgents.json
+++ b/src/test/resources/hover/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/multiple-entry-point/common.soar
+++ b/src/test/resources/multiple-entry-point/common.soar
@@ -1,0 +1,7 @@
+# This file is sourced by both entry points.
+
+sp "match-name
+    (state <s> ^name $agent_name)
+-->
+    (write (crlf) |my name is $agent_name|)
+"

--- a/src/test/resources/multiple-entry-point/primary.soar
+++ b/src/test/resources/multiple-entry-point/primary.soar
@@ -1,0 +1,3 @@
+set agent_name primary
+
+source common.soar

--- a/src/test/resources/multiple-entry-point/secondary.soar
+++ b/src/test/resources/multiple-entry-point/secondary.soar
@@ -1,0 +1,3 @@
+set agent_name secondary
+
+source common.soar

--- a/src/test/resources/multiple-entry-point/soarAgents.json
+++ b/src/test/resources/multiple-entry-point/soarAgents.json
@@ -1,0 +1,13 @@
+{
+    "entryPoints": [
+        {
+            "name": "primary",
+            "path": "primary.soar"
+        },
+        {
+            "name": "secondary",
+            "path": "secondary.soar"
+        }
+    ],
+    "active": "primary"
+}

--- a/src/test/resources/parsing/soarAgents.json
+++ b/src/test/resources/parsing/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/rename/soarAgents.json
+++ b/src/test/resources/rename/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/signature/soarAgents.json
+++ b/src/test/resources/signature/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/source-exception/soarAgents.json
+++ b/src/test/resources/source-exception/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}

--- a/src/test/resources/source-exception/test.soar
+++ b/src/test/resources/source-exception/test.soar
@@ -1,11 +1,3 @@
-# This is the root load.soar of a multi-file project.
-
-source micro-ngs/load.soar
-source productions.soar
-
-# Attempting to load this file should cause an error.
-source missing-file.soar
-
 # Using Tcl exceptions is not common in Soar programs, but apparently
 # people do this! The following should not result in an error.
 if { [catch {source "non-existant-file.tcl"}] } {

--- a/src/test/resources/special path(chars)!~'+ű/soarAgents.json
+++ b/src/test/resources/special path(chars)!~'+ű/soarAgents.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": [
+        {
+            "path": "test.soar"
+        }
+    ]
+}


### PR DESCRIPTION
Implementing #22 

So far, analyses are being run for each entry point that is specified. Many of the queries need some slight refactoring. In most cases, we can just run the query for each analysis and then deduplicate the results.

- [x] `textDocument/definition`: Returns a list of locations; if all analyses agree, then it will contain one element, but if they differ then multiple results are returned.
- [x] `textDocument/hover`: Right now we're just showing the value for the active agent.
- [x] `textDocument/references`: Returns the references that are found along all code paths that go through the point at which you made the request. So if files `A` and `B` each source file `C`, then making the request in file `A` will only return results found in `A` and `C`, whereas making the request in file `C` will return results found in all three files.
- [x] `textDocument/rename`: Not yet implemented (still using active entry point)
- [x] `textDocument/signatureHelp`: Not yet implemented (still using active entry point)
- [x] Tcl expansions: Still using active entry point, which I believe is the behaviour we want to keep (at least for now)
- [x] `textDocument/completion`: Still using the active entry point. I think this is fine, but if anyone disagrees we can refactor it.

**Note**: In VSCode (and maybe other editors) I was seeing the system get into a bad state, where the server was still fuctioning correctly (as in, I could see the correct results in the log) but the editor itself was not displaying results. I believe the issue was that multiple analysis threads were sending diagnostics at the same time, so the communication between server and client was corrupted. I have not confirmed this hypothesis, but I did restrict all analyses to running on a single thread, and things seem to be working fine now.

> As usual, the Sublime LSP integration lags behind. For example, if `textDocument/definition` returns multiple results, then both VSCode and Emacs will open a menu/dialog to handle this situation. Sublime will just go to the first result.