### PR TITLE
Add dependency on a VSCode Tcl extension.

### DIFF
--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -89,7 +89,8 @@
     "vscode-languageclient": "^5.2.1"
   },
   "extensionDependencies": [
-    "bdegrend.soar"
+    "bdegrend.soar",
+    "sleutho.tcl"
   ],
   "scripts": {
     "vscode:prepublish": "rm -rf ./soar-language-server && (cd ../../ && ./gradlew installShadowDist) && cp -r ../../build/install/soar-language-server-shadow ./soar-language-server && npm run compile",


### PR DESCRIPTION
This makes sure that when you install the VSCode extension, you'll get syntax highlighting in Tcl files as well.

If Bryan decides to update his extension to also act on Tcl files, then we might consider reverting this change.