### PR TITLE
Clear file contents before inserting expanded Tcl

### DIFF
--- a/src/main/java/com/soartech/soarls/SoarDocumentService.java
+++ b/src/main/java/com/soartech/soarls/SoarDocumentService.java
@@ -274,7 +274,15 @@ public class SoarDocumentService implements TextDocumentService {
     Function<String, CompletableFuture<ApplyWorkspaceEditResponse>> editFile =
         contents ->
             tclExpansionFile()
-                .thenCompose(file -> client.applyEdit(makeParams.apply(file, contents)));
+                .thenCompose(
+                    file ->
+                        client
+                            // We first clear the contents so that the client will scroll to the top
+                            // of the file, then we insert the actual contents. This ensures that
+                            // after the edit, the contents of the file are in view.
+                            .applyEdit(makeParams.apply(file, ""))
+                            .thenComposeAsync(
+                                response -> client.applyEdit(makeParams.apply(file, contents))));
 
     // Try to retrieve expanded production bodies and modify the expansion file; if this fails,
     // that's okay. Then, we return our actual results.


### PR DESCRIPTION
Fix for #141 

By clearing the contents first, we force clients to scroll to the top
of the buffer, so that when we later insert new text, the contents
will be in view.

The cursor itself still ends up at the end of the file; we don't
have any control over this. However, the scroll position is where we
need it to be.