### PR TITLE
Use code lenses to indicate which agent(s) a file belongs to.

### DIFF
--- a/src/main/java/com/soartech/soarls/Server.java
+++ b/src/main/java/com/soartech/soarls/Server.java
@@ -3,6 +3,7 @@ package com.soartech.soarls;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentLinkOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
@@ -74,6 +75,7 @@ public class Server implements LanguageServer, LanguageClientAware {
     capabilities.setDocumentLinkProvider(new DocumentLinkOptions());
     capabilities.setRenameProvider(true);
     capabilities.setDocumentSymbolProvider(true);
+    capabilities.setCodeLensProvider(new CodeLensOptions());
 
     return CompletableFuture.completedFuture(new InitializeResult(capabilities));
   }

--- a/src/test/java/com/soartech/soarls/CodeLensTest.java
+++ b/src/test/java/com/soartech/soarls/CodeLensTest.java
@@ -1,0 +1,35 @@
+package com.soartech.soarls;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.CodeLensOptions;
+import org.eclipse.lsp4j.CodeLensParams;
+import org.junit.jupiter.api.Test;
+
+/** We use code lenses at the tops of files to indicate which agent(s) a file belongs to. */
+public class CodeLensTest extends LanguageServerTestFixture {
+  public CodeLensTest() throws Exception {
+    super("multiple-entry-point");
+  }
+
+  @Test
+  void checkCapabilities() {
+    assertEquals(capabilities.getCodeLensProvider(), new CodeLensOptions());
+  }
+
+  @Test
+  void agentMembership() throws Exception {
+    CodeLensParams params = new CodeLensParams(fileId("common.soar"));
+    List<? extends CodeLens> codeLenses =
+        languageServer.getTextDocumentService().codeLens(params).get();
+    CodeLens codeLens =
+        codeLenses
+            .stream()
+            .filter(lens -> lens.getRange().equals(range(0, 0, 0, 0)))
+            .findAny()
+            .get();
+    assertEquals(codeLens.getCommand().getTitle(), "Member of primary, secondary");
+  }
+}


### PR DESCRIPTION
Implements #73 