### PR TITLE
Switch JSoar dependency to published version on Maven Central.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "jsoar"]
-	path = jsoar
-	url = https://github.com/soartech/jsoar.git
-    branch = language-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ cache:
 #  - gpg --import .travis/secret.gpg
 
 install:
-  # JSoar needs to be on the classpath in order for the shadow tasks
-  # to successfully be configured - it's not enough to simply declare
-  # it as a task dependency.
-  - ./gradlew compileJSoar
   - (cd integrations/vscode && npm install)
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: "{branch} {build}"
 
 install:
-  - git submodule -q update --init
-  - gradlew.bat compileJSoar
   - cd integrations/vscode && npm install && cd ../../
 
 build_script:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'application'
     id 'maven'
     id 'signing'
-    id 'com.github.dkorotych.gradle-maven-exec' version '2.2.1'
     id 'com.github.johnrengelman.shadow' version '5.1.0'
     id 'com.dorongold.task-tree' version '1.4'
     id 'io.freefair.git-version' version '2.5.11'
@@ -36,10 +35,10 @@ dependencies {
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.8.1'
 
     // We are currently depending on a JSoar version that is in flux.
-    implementation('com.soartech:jsoar-core:4.0-SNAPSHOT') {
+    implementation('com.soartech:jsoar-core:4.0.0') {
         exclude group: 'junit'
     }
-    implementation('com.soartech:jsoar-tcl:4.0-SNAPSHOT') {
+    implementation('com.soartech:jsoar-tcl:4.0.0') {
         exclude group: 'junit'
     }
 
@@ -47,19 +46,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
 }
-
-task compileJSoar(type: MavenExec) {
-    workingDir 'jsoar/'
-    goals 'install'
-    options {
-        define = [
-            'maven.test.skip': 'true',
-            'maven.javadoc.skip': 'true'
-        ]
-        batchMode true
-    }
-}
-classes.dependsOn compileJSoar
 
 googleJavaFormat {
     include 'src/'

--- a/src/main/java/com/soartech/soarls/analysis/Analysis.java
+++ b/src/main/java/com/soartech/soarls/analysis/Analysis.java
@@ -39,7 +39,7 @@ import org.eclipse.lsp4j.Range;
 import org.jsoar.kernel.Agent;
 import org.jsoar.kernel.SoarException;
 import org.jsoar.kernel.exceptions.SoarInterpreterException;
-import org.jsoar.kernel.exceptions.SoftTclInterpreterException;
+import org.jsoar.kernel.exceptions.SoftInterpreterException;
 import org.jsoar.kernel.exceptions.TclInterpreterException;
 import org.jsoar.util.SourceLocation;
 import org.jsoar.util.commands.SoarCommand;
@@ -523,7 +523,7 @@ public class Analysis {
 
                   // Add diagnostics for any "soft" exceptions that were thrown and caught but not
                   // propagated up.
-                  for (SoftTclInterpreterException e :
+                  for (SoftInterpreterException e :
                       agent.getInterpreter().getExceptionsManager().getExceptions()) {
                     Range range = file.rangeForNode(ctx.currentNode);
                     String message = e.getMessage().trim();


### PR DESCRIPTION
This also removes the git submodule, and the gradle-maven-exec plugin
that built JSoar from source. It also includes a fix for a small API
change in JSoar.