### PR TITLE
Minimal error printing

### DIFF
--- a/src/main/java/com/soartech/soarls/Documents.java
+++ b/src/main/java/com/soartech/soarls/Documents.java
@@ -89,7 +89,7 @@ public class Documents {
       String contents = Joiner.on("\n").join(lines);
       return new SoarFile(uri, contents);
     } catch (Exception e) {
-      LOG.error("Failed to open file", e);
+      LOG.error("Failed to open file " + uri.toString());
       return null;
     }
   }

--- a/src/main/java/com/soartech/soarls/SoarDocumentService.java
+++ b/src/main/java/com/soartech/soarls/SoarDocumentService.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -152,6 +153,7 @@ public class SoarDocumentService implements TextDocumentService {
         .entryPoints()
         .map(entryPoint -> workspaceRootUri.resolve(entryPoint.path))
         .map(uri -> getAnalysis(uri))
+        .filter(Objects::nonNull)
         .collect(collector);
   }
 

--- a/src/main/java/com/soartech/soarls/analysis/Analysis.java
+++ b/src/main/java/com/soartech/soarls/analysis/Analysis.java
@@ -221,7 +221,7 @@ public class Analysis {
       LOG.info("Completed analysis {}", analysis);
       return analysis.toProjectAnalysis();
     } catch (Exception e) {
-      LOG.error("running analysis", e);
+      LOG.warn("Unable to analyse " + entryPointUri.toString());
       return null;
     } finally {
       analysis.agent.dispose();


### PR DESCRIPTION
This is a pretty small change (branched off from my comment-rendering branch, so probably best to merge that one first). Basically it makes the debug comments far less verbose. Only developers really need the stack traces.